### PR TITLE
when waiting for plugins, look for .hpi too

### DIFF
--- a/reactive/cwr.py
+++ b/reactive/cwr.py
@@ -160,6 +160,8 @@ def wait_for_plugin(plugin, wait_for_secs=300):
         if time.time() > timeout:
             return False
         all_plugins = os.listdir("/var/lib/jenkins/plugins")
+        if "{}.hpi".format(plugin) in all_plugins:
+            return True
         if "{}.jpi".format(plugin) in all_plugins:
             return True
         time.sleep(15)


### PR DESCRIPTION
I noticed this in a recent cwr log:

```
2016-12-09 21:05:27 INFO juju-log jenkins:7: Installing plugin github. Restart required: False
2016-12-09 21:10:28 INFO juju-log jenkins:7: installation of github did not complete on time.
2016-12-09 21:10:30 INFO juju-log jenkins:7: Installing plugin ghprb. Restart required: False
2016-12-09 21:15:30 INFO juju-log jenkins:7: installation of ghprb did not complete on time.
```

I went looking for the *.jpi plugin that was apparently missing, and I found
these plugins *did* exist, but they were named *.hpi. Looks like both .hpi
and .jpi are valid plugin extensions, so I updated the `wait_for_plugin()` method
to look for both.