### PR TITLE
Support credentials for public clouds

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,18 @@ the registration token from the above `juju add-user` command.
     juju run-action cwr/0 register-controller name=<controller-name> \
         token=<registration-token>
 
-Alternatively you can login into jenkins (user admin) and build the
-`RegisterController` job. To un-register a controller, call the
-`unregister-controller` action trigger the `UnregisterController` jenkins job.
-In both cases, you need to provide the user friendly name you specified during
-controller registration.
+If you're using a cloud that requires credentials (i.e., anything other than
+the LXD provider), you will also need to provide those credentials as well,
+as base64-encoded YAML:
+
+    juju run-action cwr/0 set-credentials cloud=<cloud-name> \
+        credentials="$(base64 credentials.yaml)"
+
+You can find your credentials in `~/.local/share/juju/credentials.yaml`,
+but you may want to extract and share just the portions that will be
+used with the CI system.  In the future, Juju should provide a way to
+share access to the credentials without having to share the credentials
+themselves.
 
 To push and release build artifacts to the Juju store directly from the CI,
 you will need to initialize the session between this charm and the store. To do
@@ -38,12 +45,11 @@ token. For example:
     export TOKEN=`base64 ~/.local/share/juju/store-usso-token`
     juju run-action cwr/0 store-login charmstore-usso-token="$TOKEN"
 
-The `InitJujuStoreSession` jenkins job requires you to enter your charm store
-credentials in the Jenkins UI.
-
 The charm store session will remain active while the CI system is online. To
-terminate the session, either run the `store-logout` action or trigger the
-`LogoutFromJujuStore` job from within Jenkins.
+terminate the session, either run the `store-logout` action.
+
+Note that these actions are also available as jobs in Jenkins and can be run
+from there instead.
 
 
 # Using CWR to build your Charms

--- a/actions.yaml
+++ b/actions.yaml
@@ -90,3 +90,11 @@ unregister-controller:
     required: ['name']
 list-controllers:
     description: List all available controllers.
+set-credentials:
+    description: Add or update credentials for a cloud
+    params:
+        cloud:
+            description: Name of cloud to update credentials for
+        credentials:
+            description: Cloud credentials as base64-encoded YAML
+            type: string

--- a/actions/set-credentials
+++ b/actions/set-credentials
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+cleanup() {
+    rm -f credentials.yaml
+}
+
+set_creds() {
+    cloud=$(action-get 'cloud')
+    action-get 'credentials' | base64 -d > credentials.yaml
+    trap cleanup EXIT
+
+    sudo -u jenkins -- juju add-credential "$cloud" --replace -f credentials.yaml
+}
+
+output="$(set_creds 2>&1)"
+if [[ $? != 0 ]]; then
+    action-fail "$output"
+else
+    action-set message="$output"
+fi

--- a/actions/set-credentials
+++ b/actions/set-credentials
@@ -2,13 +2,14 @@
 
 cleanup() {
     rm -f credentials.yaml
+    rm -f credentials.base64
 }
 
 set_creds() {
     cloud=$(action-get 'cloud')
-    action-get 'credentials' | base64 -d > credentials.yaml
+    action-get 'credentials' | sed 's/ /\n/g' > credentials.base64
+    cat credentials.base64 | base64 -d > credentials.yaml
     trap cleanup EXIT
-
     sudo -u jenkins -- juju add-credential "$cloud" --replace -f credentials.yaml
 }
 

--- a/jobs/RunCwr/config.xml
+++ b/jobs/RunCwr/config.xml
@@ -40,11 +40,17 @@ juju switch $CONTROLLER
 
 # we have to figure out which credential to use because of:
 # https://bugs.launchpad.net/juju/+bug/1652171
-cloud=$(juju add-model wont-be-added --credential invalid-credential 2>&amp;1 | cut -d'"' -f 4)
-credential=$(juju credentials --format=json | jq -r '.credentials.'${cloud}'."cloud-credentials" | keys[0]')
+tryaddmodel=$(juju add-model wont-be-added --credential invalid-credential 2>&amp;1) || true
+if expr "$tryaddmodel" : '.* localhost .*'
+then
+    juju add-model test-cwr-$CHARM_NAME-$BUILD_NUMBER
+else
+    cloud=$(echo $tryaddmodel | cut -d'"' -f 4)
+    credential=$(juju credentials --format=json | jq -r '.credentials.'${cloud}'."cloud-credentials" | keys[0]')
+    juju add-model test-cwr-$CHARM_NAME-$BUILD_NUMBER --credential="$credential"
+fi
 
-juju add-model test-$BUILD_NUMBER --credential="$credential"
-cwr $CONTROLLER:test-$BUILD_NUMBER totest.yaml
+cwr $CONTROLLER:test-cwr-$CHARM_NAME-$BUILD_NUMBER totest.yaml
 </command>
     </hudson.tasks.Shell>
   </builders>
@@ -52,7 +58,7 @@ cwr $CONTROLLER:test-$BUILD_NUMBER totest.yaml
       <org.jenkinsci.plugins.postbuildscript.PostBuildScript plugin="postbuildscript@0.17">
       <buildSteps>
         <hudson.tasks.Shell>
-          <command>juju destroy-model test-$BUILD_NUMBER -y</command>
+          <command>juju destroy-model test-cwr-$CHARM_NAME-$BUILD_NUMBER -y</command>
         </hudson.tasks.Shell>
       </buildSteps>
       <scriptOnlyIfSuccess>false</scriptOnlyIfSuccess>

--- a/jobs/RunCwr/config.xml
+++ b/jobs/RunCwr/config.xml
@@ -37,7 +37,13 @@
 echo &quot;bundle: $BUILD_CHARM_TARGET&quot; &gt;&gt; totest.yaml
 echo &quot;bundle_name: $CHARM_NAME&quot; &gt;&gt; totest.yaml
 juju switch $CONTROLLER
-juju add-model test-$BUILD_NUMBER
+
+# we have to figure out which credential to use because of:
+# https://bugs.launchpad.net/juju/+bug/1652171
+cloud=$(juju add-model wont-be-added --credential invalid-credential 2>&amp;1 | cut -d'"' -f 4)
+credential=$(juju credentials --format=json | jq -r '.credentials.'${cloud}'."cloud-credentials" | keys[0]')
+
+juju add-model test-$BUILD_NUMBER --credential="$credential"
 cwr $CONTROLLER:test-$BUILD_NUMBER totest.yaml
 </command>
     </hudson.tasks.Shell>

--- a/layer.yaml
+++ b/layer.yaml
@@ -4,4 +4,5 @@ options:
   basic:
     packages:
       - unzip
+      - jq
     use_venv: true

--- a/templates/BuildMyCharm/config.xml
+++ b/templates/BuildMyCharm/config.xml
@@ -58,7 +58,13 @@ fi
 charm build $SERIES_FLAG
 
 juju switch {{controller}}
-juju add-model test-{{charmname}}-$BUILD_NUMBER
+
+# we have to figure out which credential to use because of:
+# https://bugs.launchpad.net/juju/+bug/1652171
+cloud=$(juju add-model wont-be-added --credential invalid-credential 2>&amp;1 | cut -d'"' -f 4)
+credential=$(juju credentials --format=json | jq -r '.credentials.'${cloud}'."cloud-credentials" | keys[0]')
+
+juju add-model test-{{charmname}}-$BUILD_NUMBER --credential="$credential"
 
 if [ -z "{{referencebundle}}" ]
 then

--- a/templates/BuildMyCharm/config.xml
+++ b/templates/BuildMyCharm/config.xml
@@ -61,10 +61,15 @@ juju switch {{controller}}
 
 # we have to figure out which credential to use because of:
 # https://bugs.launchpad.net/juju/+bug/1652171
-cloud=$(juju add-model wont-be-added --credential invalid-credential 2>&amp;1 | cut -d'"' -f 4)
-credential=$(juju credentials --format=json | jq -r '.credentials.'${cloud}'."cloud-credentials" | keys[0]')
-
-juju add-model test-{{charmname}}-$BUILD_NUMBER --credential="$credential"
+tryaddmodel=$(juju add-model wont-be-added --credential invalid-credential 2>&amp;1) || true
+if expr "$tryaddmodel" : '.* localhost .*'
+then
+    juju add-model test-{{charmname}}-$BUILD_NUMBER
+else
+    cloud=$(echo $tryaddmodel | cut -d'"' -f 4)
+    credential=$(juju credentials --format=json | jq -r '.credentials.'${cloud}'."cloud-credentials" | keys[0]')
+    juju add-model test-{{charmname}}-$BUILD_NUMBER --credential="$credential"
+fi
 
 if [ -z "{{referencebundle}}" ]
 then


### PR DESCRIPTION
There's no way currently to share access to credentials when sharing
access to a controller.  Thus, for public clouds which require
credentials (unlike the LXD provider), the credentials have to be
explicitly given to the charm in addition to the controller.

Fixes #19