### PR TITLE
action fail and artifacts on failure

### DIFF
--- a/actions/build-on-commit
+++ b/actions/build-on-commit
@@ -9,7 +9,7 @@ activate_venv()
 from charmhelpers.core import hookenv  # noqa: E402
 from charms.reactive import RelationBase  # noqa: E402
 import cwrhelpers  # noqa: E402
-from jenkins import Jenkins  # noqa: E402
+from jenkins import Jenkins, JenkinsException  # noqa: E402
 
 
 def add_job():
@@ -50,7 +50,10 @@ def add_job():
         data = infile.read()
         for src, target in rep.items():
             data = data.replace(src, target)
-        jclient.create_job("charm-{}".format(charm_name), data)
+        try:
+            jclient.create_job("charm-{}".format(charm_name), data)
+        except JenkinsException as e:
+            cwrhelpers.fail_action(str(e))
 
 
 if __name__ == "__main__":

--- a/actions/build-on-release
+++ b/actions/build-on-release
@@ -9,7 +9,7 @@ activate_venv()
 from charmhelpers.core import hookenv  # noqa: E402
 from charms.reactive import RelationBase  # noqa: E402
 import cwrhelpers  # noqa: E402
-from jenkins import Jenkins  # noqa: E402
+from jenkins import Jenkins, JenkinsException  # noqa: E402
 
 
 def add_job():
@@ -51,7 +51,10 @@ def add_job():
         data = infile.read()
         for src, target in rep.items():
             data = data.replace(src, target)
-        jclient.create_job("release-charm-{}".format(charm_name), data)
+        try:
+            jclient.create_job("release-charm-{}".format(charm_name), data)
+        except JenkinsException as e:
+            cwrhelpers.fail_action(str(e))
 
 
 if __name__ == "__main__":

--- a/templates/BuildMyCharm/config.xml
+++ b/templates/BuildMyCharm/config.xml
@@ -98,8 +98,8 @@ rm -f totest.yaml
 echo "bundle: /tmp/bundles/{{bundle_fname}}" &gt;&gt; totest.yaml
 echo "bundle_name: {{charmname}}_in_{{bundle_fname}}" &gt;&gt; totest.yaml
 echo "bundle_file: bundle.yaml" >> totest.yaml
-cwr -F {{controller}}:test-{{charmname}}-$BUILD_NUMBER totest.yaml --results-dir /srv/artifacts --test-id $BUILD_NUMBER
 ln -s /srv/artifacts/{{charmname}}_in_{{bundle_fname}}/$BUILD_NUMBER /var/lib/jenkins/jobs/$JOB_NAME/builds/$BUILD_NUMBER/archive
+cwr -F {{controller}}:test-{{charmname}}-$BUILD_NUMBER totest.yaml --results-dir /srv/artifacts --test-id $BUILD_NUMBER
 
 if [ ! -z "{{pushtochannel}}" ]
 then


### PR DESCRIPTION
Provide useful feedback if job creation fails, and link artifacts before running cwr so that they are available on failure.