### PR TITLE
Added MATRIX_OUTPUT_DIR to env when cwr runs.

### DIFF
--- a/jobs/RunCwr/config.xml
+++ b/jobs/RunCwr/config.xml
@@ -58,7 +58,7 @@ function cleanup_model() {
 }
 trap cleanup_model EXIT
 
-env MATRIX_OUTPUT_DIR=/srv/artifacts cwr -F $CONTROLLER:test-cwr-$CHARM_NAME-$BUILD_NUMBER totest.yaml --results-dir /srv/artifacts --test-id $BUILD_NUMBER
+env MATRIX_OUTPUT_DIR=/srv/artifacts/{{charm_fname}}_in_{{bundle_fname}}/$BUILD_NUMBER cwr -F $CONTROLLER:test-cwr-$CHARM_NAME-$BUILD_NUMBER totest.yaml --results-dir /srv/artifacts --test-id $BUILD_NUMBER
 </command>
     </hudson.tasks.Shell>
   </builders>

--- a/jobs/RunCwr/config.xml
+++ b/jobs/RunCwr/config.xml
@@ -58,7 +58,7 @@ function cleanup_model() {
 }
 trap cleanup_model EXIT
 
-cwr -F $CONTROLLER:test-cwr-$CHARM_NAME-$BUILD_NUMBER totest.yaml --results-dir /srv/artifacts --test-id $BUILD_NUMBER
+env MATRIX_OUTPUT_DIR=/srv/artifacts cwr -F $CONTROLLER:test-cwr-$CHARM_NAME-$BUILD_NUMBER totest.yaml --results-dir /srv/artifacts --test-id $BUILD_NUMBER
 </command>
     </hudson.tasks.Shell>
   </builders>

--- a/jobs/RunCwr/config.xml
+++ b/jobs/RunCwr/config.xml
@@ -58,7 +58,10 @@ function cleanup_model() {
 }
 trap cleanup_model EXIT
 
-env MATRIX_OUTPUT_DIR=/srv/artifacts/{{charm_fname}}_in_{{bundle_fname}}/$BUILD_NUMBER cwr -F $CONTROLLER:test-cwr-$CHARM_NAME-$BUILD_NUMBER totest.yaml --results-dir /srv/artifacts --test-id $BUILD_NUMBER
+ARTIFACTS_DIR=/srv/artifacts/{{charm_fname}}_in_{{bundle_fname}}/$BUILD_NUMBER
+mkdir -p ARTIFACTS_DIR
+ln -s $ARTIFACTS_DIR /var/lib/jenkins/jobs/$JOB_NAME/builds/$BUILD_NUMBER/archive
+env MATRIX_OUTPUT_DIR=$ARTIFACTS_DIR cwr -F $CONTROLLER:test-cwr-$CHARM_NAME-$BUILD_NUMBER totest.yaml --results-dir /srv/artifacts --test-id $BUILD_NUMBER
 </command>
     </hudson.tasks.Shell>
   </builders>

--- a/templates/BuildMyCharm/config.xml
+++ b/templates/BuildMyCharm/config.xml
@@ -130,7 +130,7 @@ trap "${new_trap}" EXIT
 
 # Link cwr artifacts for visibility in the jenkins job
 ln -s /srv/artifacts/{{charm_fname}}_in_{{bundle_fname}}/$BUILD_NUMBER /var/lib/jenkins/jobs/$JOB_NAME/builds/$BUILD_NUMBER/archive
-env MATRIX_OUTPUT_DIR=/srv/artifacts cwr -F ${MODELS_TO_TEST} totest.yaml --results-dir /srv/artifacts --test-id $BUILD_NUMBER
+env MATRIX_OUTPUT_DIR=/srv/artifacts/{{charm_fname}}_in_{{bundle_fname}}/$BUILD_NUMBER cwr -F ${MODELS_TO_TEST} totest.yaml --results-dir /srv/artifacts --test-id $BUILD_NUMBER
 
 if [ ! -z "{{pushtochannel}}" ]
 then

--- a/templates/BuildMyCharm/config.xml
+++ b/templates/BuildMyCharm/config.xml
@@ -130,7 +130,7 @@ trap "${new_trap}" EXIT
 
 # Link cwr artifacts for visibility in the jenkins job
 ln -s /srv/artifacts/{{charm_fname}}_in_{{bundle_fname}}/$BUILD_NUMBER /var/lib/jenkins/jobs/$JOB_NAME/builds/$BUILD_NUMBER/archive
-cwr -F ${MODELS_TO_TEST} totest.yaml --results-dir /srv/artifacts --test-id $BUILD_NUMBER
+env MATRIX_OUTPUT_DIR=/srv/artifacts cwr -F ${MODELS_TO_TEST} totest.yaml --results-dir /srv/artifacts --test-id $BUILD_NUMBER
 
 if [ ! -z "{{pushtochannel}}" ]
 then

--- a/templates/BuildMyCharm/config.xml
+++ b/templates/BuildMyCharm/config.xml
@@ -129,8 +129,10 @@ new_trap="transform_results; ${old_trap}"
 trap "${new_trap}" EXIT
 
 # Link cwr artifacts for visibility in the jenkins job
-ln -s /srv/artifacts/{{charm_fname}}_in_{{bundle_fname}}/$BUILD_NUMBER /var/lib/jenkins/jobs/$JOB_NAME/builds/$BUILD_NUMBER/archive
-env MATRIX_OUTPUT_DIR=/srv/artifacts/{{charm_fname}}_in_{{bundle_fname}}/$BUILD_NUMBER cwr -F ${MODELS_TO_TEST} totest.yaml --results-dir /srv/artifacts --test-id $BUILD_NUMBER
+ARTIFACTS_DIR=/srv/artifacts/{{charm_fname}}_in_{{bundle_fname}}/$BUILD_NUMBER
+mkdir -p $ARTIFACTS_DIR
+ln -s $ARTIFACTS_DIR /var/lib/jenkins/jobs/$JOB_NAME/builds/$BUILD_NUMBER/archive
+env MATRIX_OUTPUT_DIR=$ARTIFACTS_DIR cwr -F ${MODELS_TO_TEST} totest.yaml --results-dir /srv/artifacts --test-id $BUILD_NUMBER
 
 if [ ! -z "{{pushtochannel}}" ]
 then


### PR DESCRIPTION
@johnsca @kwmonroe @ktsakalozos This activates the code in https://github.com/juju-solutions/matrix/pull/69

I've verified that setting this env variable works when I run cwr locally, and I've run bundletester against this charm. I still need to jump through the hoops to test the cwr-ci bundle with a local version of this charm. I'm pushing this PR now, in case somebody can beat me to the punch in getting that last test setup and run.