### PR TITLE
Block if plugins do not get deployed

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -110,6 +110,11 @@ def get_rest_path():
 
 
 def report_status():
+    if is_state('jenkins.jobs.failed'):
+        hookenv.status_set('blocked',
+                           'Initialisation failed. Please, redeploy cwr.')
+        return
+
     if not is_state('jenkins.available'):
         hookenv.status_set('waiting',
                            'Waiting for jenkins to become available.')

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -112,7 +112,8 @@ def get_rest_path():
 def report_status():
     if is_state('jenkins.jobs.failed'):
         hookenv.status_set('blocked',
-                           'Initialisation failed. Please, redeploy cwr.')
+                           'Failed to install Jenkins plugins. '
+                           'Retry by removing/adding cwr relation.')
         return
 
     if not is_state('jenkins.available'):


### PR DESCRIPTION
Should fix: https://github.com/juju-solutions/layer-cwr/issues/63

The charm will block prompting for a reinstall (re-add jenkins-cwr relation).

Retrying does not play well here.
I have seen a case where Jenkins mistakenly reports that
the plugin is installed causing an infinite retry loop :(
