### PR TITLE
Fix tests for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: trusty
 sudo: required
 language: python
 python:
@@ -6,9 +6,6 @@ python:
 
 install:
  - pip install tox
- - sudo add-apt-repository -y ppa:juju/stable
- - sudo apt-get update
- - sudo apt-get install -y charm-tools juju
 
 script:
  - make all

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ apt_prereqs:
 lint: apt_prereqs
 	@tox --notest
 	@PATH=.tox/py34/bin:.tox/py35/bin flake8 $(wildcard hooks reactive lib unit_tests tests)
-	@charm proof
 
 .PHONY: unit_test
 unit_test: apt_prereqs

--- a/scripts/bundlebuilder.py
+++ b/scripts/bundlebuilder.py
@@ -69,10 +69,10 @@ class Bundle(object):
         # Load the ci-info.yaml
         if ci_info_file:
             with open(ci_info_file, 'r+') as stream:
-                self.ci_info = safe_load(stream)
+                self.ci_info = safe_load(stream) or dict()
         elif os.path.isfile("{}/ci-info.yaml".format(self.tempdir)):
             with open("{}/ci-info.yaml".format(self.tempdir), 'r+') as stream:
-                self.ci_info = safe_load(stream)
+                self.ci_info = safe_load(stream) or dict()
         else:
             self.ci_info = dict()  # or load some default ci_info
 

--- a/unit_tests/test_bundlebuilder.py
+++ b/unit_tests/test_bundlebuilder.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import os
 import unittest
 from scripts import bundlebuilder
 from unittest.mock import patch, mock_open
@@ -27,15 +28,16 @@ class TestBundlebuilder(unittest.TestCase):
 
     @patch('scripts.bundlebuilder.execute')
     def test_bundle(self, execute_mock):
-        with patch("builtins.open", mock_open(read_data=self.bundle_yaml)):
-            bundle = bundlebuilder.Bundle(
-                "http://github/myrepo",
-                "mybranch",
-                "myci-info.yaml",
-                CWR_dry_run=True,
-                store_push_dry_run=True)
-            bundle.test(build_num=1, models=["mymodel", "mymodel2"])
-            assert execute_mock.call_count is 2
+        with patch.dict(os.environ, {'JOB_NAME': 'build-bundle-mybundle'}):
+            with patch("builtins.open", mock_open(read_data=self.bundle_yaml)):
+                bundle = bundlebuilder.Bundle(
+                    "http://github/myrepo",
+                    "mybranch",
+                    "myci-info.yaml",
+                    CWR_dry_run=True,
+                    store_push_dry_run=True)
+                bundle.test(build_num=1, controllers=["lxd", "aws"])
+                assert execute_mock.call_count is 2
 
     @patch('scripts.bundlebuilder.execute')
     def test_charm(self, execute_mock):


### PR DESCRIPTION
We had issues with the charm-tools and juju packages.  Though those are both either fixed or will be fixed soon, we don't actually need juju, and if we remove `charm proof`, which should be done on the built charm anyway, we don't need charm-tools.

There were some test failures introduced since Travis became broken.