### PR TITLE
Copy the S3 credentials to the container.

### DIFF
--- a/actions/cwr-charm-commit
+++ b/actions/cwr-charm-commit
@@ -33,9 +33,6 @@ from utils import (
 )  # noqa: E402
 
 
-
-
-
 def add_job():
     '''
     Adds a job to be triggered upon a commit on github

--- a/actions/cwr-charm-commit
+++ b/actions/cwr-charm-commit
@@ -1,9 +1,19 @@
 #!/usr/bin/env python3
 
+import shutil
 import sys
 sys.path.append('lib')
+from os.path import (
+    basename,
+    join,
+)
 
-from cwrhelpers import get_s3_options  # noqa: E402
+from cwrhelpers import (
+    CONTAINER_HOME,
+    CONFIG_DIR,
+    get_s3_options,
+    HOME,
+)  # noqa: E402
 from charms.layer.basic import activate_venv  # noqa: E402
 activate_venv()
 
@@ -21,6 +31,9 @@ from utils import (
     REST_PORT,
     TRIGGER_PERIODICALLY,
 )  # noqa: E402
+
+
+
 
 
 def add_job():
@@ -56,7 +69,11 @@ def add_job():
                                "'webhooks' or 'poll'")
 
     job_name = "cwr_charm_commit_{}_in_{}".format(charm_fname, bundle_fname)
-    s3_options = get_s3_options("{}.s3cfg".format(job_name))
+
+    s3_creds = "{}.s3cfg".format(join(HOME, CONFIG_DIR, job_name))
+    s3_creds_container = join(CONTAINER_HOME, CONFIG_DIR, basename(s3_creds))
+    s3_options = get_s3_options(s3_creds, s3_creds_container)
+
     job_contents = templating.render(
         source="BuildMyCharm/config.xml",
         target=None,

--- a/actions/cwrhelpers.py
+++ b/actions/cwrhelpers.py
@@ -131,7 +131,8 @@ def get_s3_credentials(cred_name=None):
 
     Returns: access_key, secret_key
     """
-    cmd = 'juju credentials aws --format yaml --show-secrets'.split()
+    cmd = ('sudo -H -u jenkins -- juju credentials aws --format yaml '
+           '--show-secrets'.split())
     try:
         creds = subprocess.check_output(cmd)
     except subprocess.CalledProcessError as e:

--- a/unit_tests/test_cwrhelpers.py
+++ b/unit_tests/test_cwrhelpers.py
@@ -75,8 +75,8 @@ class TestS3Credentials(TestCase):
         self.assertEqual(access, 'foo')
         self.assertEqual(secret, 'bar')
         co_mock.assert_called_once_with(
-            ['juju', 'credentials', 'aws', '--format', 'yaml',
-             '--show-secrets'])
+            ['sudo', '-H', '-u', 'jenkins', '--', 'juju', 'credentials', 'aws',
+             '--format', 'yaml', '--show-secrets'])
 
     def test_get_s3_credentials_default_credential(self):
         with patch('subprocess.check_output', autospec=True,
@@ -85,8 +85,8 @@ class TestS3Credentials(TestCase):
         self.assertEqual(access, 'foo-2')
         self.assertEqual(secret, 'bar-2')
         co_mock.assert_called_once_with(
-            ['juju', 'credentials', 'aws', '--format', 'yaml',
-             '--show-secrets'])
+            ['sudo', '-H', '-u', 'jenkins', '--', 'juju', 'credentials', 'aws',
+             '--format', 'yaml', '--show-secrets'])
 
     def test_get_s3_credentials_single_credential(self):
         with patch('subprocess.check_output', autospec=True,
@@ -95,8 +95,8 @@ class TestS3Credentials(TestCase):
         self.assertEqual(access, 'foo')
         self.assertEqual(secret, 'bar')
         co_mock.assert_called_once_with(
-            ['juju', 'credentials', 'aws', '--format', 'yaml',
-             '--show-secrets'])
+            ['sudo', '-H', '-u', 'jenkins', '--', 'juju', 'credentials', 'aws',
+             '--format', 'yaml', '--show-secrets'])
 
     def test_get_s3_credentials_empty(self):
         with patch('subprocess.check_output', autospec=True,
@@ -106,8 +106,8 @@ class TestS3Credentials(TestCase):
                 with self.assertRaises(SystemExit):
                     get_s3_credentials()
         co_mock.assert_called_once_with(
-            ['juju', 'credentials', 'aws', '--format', 'yaml',
-             '--show-secrets'])
+            ['sudo', '-H', '-u', 'jenkins', '--', 'juju', 'credentials', 'aws',
+             '--format', 'yaml', '--show-secrets'])
         fa_mock.assert_called_once_with(
             'AWS credentials not found. Set AWS credentials by running '
             '"set-credentials" action.')
@@ -120,8 +120,8 @@ class TestS3Credentials(TestCase):
                 with self.assertRaises(SystemExit):
                     get_s3_credentials()
         co_mock.assert_called_once_with(
-            ['juju', 'credentials', 'aws', '--format', 'yaml',
-             '--show-secrets'])
+            ['sudo', '-H', '-u', 'jenkins', '--', 'juju', 'credentials', 'aws',
+             '--format', 'yaml', '--show-secrets'])
         fa_mock.assert_called_once_with(
             'AWS credentials not found. Set AWS credentials by running '
             '"set-credentials" action.')
@@ -134,8 +134,8 @@ class TestS3Credentials(TestCase):
                 with self.assertRaises(SystemExit):
                     get_s3_credentials()
         co_mock.assert_called_once_with(
-            ['juju', 'credentials', 'aws', '--format', 'yaml',
-             '--show-secrets'])
+            ['sudo', '-H', '-u', 'jenkins', '--', 'juju', 'credentials', 'aws',
+             '--format', 'yaml', '--show-secrets'])
         fa_mock.assert_called_once_with(
             'Credentials not found. Set AWS credentials by running '
             '"set-credentials" action.')
@@ -168,8 +168,8 @@ class TestGetS3Options(TestCase):
             '--bucket bucket-foo --results-dir results-dir-foo --s3-creds '
             '{} --s3-private'.format(s3_config.name))
         co_mock.assert_called_once_with(
-            ['juju', 'credentials', 'aws', '--format', 'yaml',
-             '--show-secrets'])
+            ['sudo', '-H', '-u', 'jenkins', '--', 'juju', 'credentials', 'aws',
+             '--format', 'yaml', '--show-secrets'])
 
     def test_get_s3_options_public(self):
         with patch('actions.cwrhelpers.hookenv', autospec=True) as ch_mock:
@@ -184,8 +184,8 @@ class TestGetS3Options(TestCase):
             '--bucket bucket-foo --results-dir results-dir-foo --s3-creds '
             '{}'.format(s3_config.name))
         co_mock.assert_called_once_with(
-            ['juju', 'credentials', 'aws', '--format', 'yaml',
-             '--show-secrets'])
+            ['sudo', '-H', '-u', 'jenkins', '--', 'juju', 'credentials', 'aws',
+             '--format', 'yaml', '--show-secrets'])
 
     def test_get_s3_options_no_bucket(self):
         with patch('actions.cwrhelpers.hookenv', autospec=True) as ch_mock:

--- a/unit_tests/test_cwrhelpers.py
+++ b/unit_tests/test_cwrhelpers.py
@@ -145,7 +145,8 @@ class TestGetS3Options(TestCase):
 
     def test_create_s3_config_file(self):
         with NamedTemporaryFile() as s3_config:
-            create_s3_config_file(s3_config.name, 'foo', 'bar')
+            with patch('shutil.chown', autospec=True) as chown_mock:
+                create_s3_config_file(s3_config.name, 'foo', 'bar')
             with open(s3_config.name) as f:
                 creds = f.read()
         expected_output = dedent("""\
@@ -162,14 +163,16 @@ class TestGetS3Options(TestCase):
                        return_value=TestS3Credentials.fake_creds
                        ) as co_mock:
                 with NamedTemporaryFile() as s3_config:
-                    s3_option = get_s3_options(s3_config.name)
+                    with patch('shutil.chown', autospec=True) as sc_mock:
+                        s3_option = get_s3_options(s3_config.name, '/foo')
         self.assertEqual(
             s3_option,
-            '--bucket bucket-foo --results-dir results-dir-foo --s3-creds '
-            '{} --s3-private'.format(s3_config.name))
+            '--bucket bucket-foo --results-dir results-dir-foo --s3-creds /foo'
+            ' --s3-private')
         co_mock.assert_called_once_with(
             ['sudo', '-H', '-u', 'jenkins', '--', 'juju', 'credentials', 'aws',
              '--format', 'yaml', '--show-secrets'])
+        sc_mock.assert_called_once_with(s3_config.name, 'jenkins', 'jenkins')
 
     def test_get_s3_options_public(self):
         with patch('actions.cwrhelpers.hookenv', autospec=True) as ch_mock:
@@ -178,19 +181,21 @@ class TestGetS3Options(TestCase):
                        return_value=TestS3Credentials.fake_creds
                        )as co_mock:
                 with NamedTemporaryFile() as s3_config:
-                    s3_option = get_s3_options(s3_config.name)
+                    with patch('shutil.chown', autospec=True) as sc_mock:
+                        s3_option = get_s3_options(s3_config.name, '/foo')
         self.assertEqual(
             s3_option,
-            '--bucket bucket-foo --results-dir results-dir-foo --s3-creds '
-            '{}'.format(s3_config.name))
+            '--bucket bucket-foo --results-dir results-dir-foo --s3-creds /foo'
+            )
         co_mock.assert_called_once_with(
             ['sudo', '-H', '-u', 'jenkins', '--', 'juju', 'credentials', 'aws',
              '--format', 'yaml', '--show-secrets'])
+        sc_mock.assert_called_once_with(s3_config.name, 'jenkins', 'jenkins')
 
     def test_get_s3_options_no_bucket(self):
         with patch('actions.cwrhelpers.hookenv', autospec=True) as ch_mock:
             ch_mock.action_get.return_value = ''
-            s3_option = get_s3_options(None)
+            s3_option = get_s3_options(None, None)
         self.assertEqual(s3_option, '')
 
 


### PR DESCRIPTION
This branch copies the S3 credential file to the container. This credential file is used by `cwr` to upload the test result to S3. 

The initial idea was to copy the the credentials file to the workspace directory but the directory is not created before the job creation and before the first build.